### PR TITLE
feat: highlight the markdown section header

### DIFF
--- a/src/formats.rs
+++ b/src/formats.rs
@@ -11,10 +11,14 @@ pub mod markdown;
 /// Enables support for markdown and other structured formats by providing format-specific parsing
 /// queries (tree-sitter uses SCM lisp queries).
 pub trait Format {
+    /// File extension for syntax highlighting (e.g., "md", "rs")
+    fn file_extension(&self) -> &'static str;
     /// Returns the tree-sitter language parser for this format.
     fn language(&self) -> tree_sitter::Language;
     /// Tree-sitter query matching section boundaries in this format.
     fn section_query(&self) -> &str;
     /// Tree-sitter query extracting section titles in this format.
     fn title_query(&self) -> &str;
+    /// Format a section heading for display with syntax highlighting
+    fn format_section_display(&self, level: usize, title: &str) -> ratatui::text::Line<'static>;
 }

--- a/src/formats/markdown.rs
+++ b/src/formats/markdown.rs
@@ -4,11 +4,19 @@
 //! and extracting section structure from ATX-style headings (# syntax).
 
 use crate::formats::Format;
+use ratatui::{
+    style::{Color, Style},
+    text::{Line, Span},
+};
 
 /// Tree-sitter queries for ATX-style markdown headings (# syntax).
 pub struct MarkdownFormat;
 
 impl Format for MarkdownFormat {
+    fn file_extension(&self) -> &'static str {
+        "md"
+    }
+
     fn language(&self) -> tree_sitter::Language {
         tree_sitter_md::LANGUAGE.into()
     }
@@ -19,5 +27,28 @@ impl Format for MarkdownFormat {
 
     fn title_query(&self) -> &'static str {
         "(atx_heading heading_content: (inline) @title)"
+    }
+
+    fn format_section_display(&self, level: usize, title: &str) -> Line<'static> {
+        // Cycle through colors for different heading levels
+        let colors = [
+            Color::Cyan,
+            Color::Green,
+            Color::Yellow,
+            Color::Magenta,
+            Color::Blue,
+            Color::Red,
+        ];
+
+        let color = colors[(level - 1) % colors.len()];
+        let prefix = "#".repeat(level);
+
+        let spans = vec![
+            Span::styled(prefix, Style::default().fg(color)),
+            Span::raw(" "),
+            Span::raw(title.to_string()),
+        ];
+
+        Line::from(spans)
     }
 }


### PR DESCRIPTION
Adds some nice syntax highlighting to the `#` part (only) of the headers in the section view
